### PR TITLE
add a shell.nix

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import kivy
 
 from kivy.config import Config

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,18 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+with pkgs;
+
+python3.pkgs.buildPythonApplication rec {
+
+  python = python3;
+
+  name = "smoopi";
+
+  nativeBuildInputs = with python.pkgs; [
+    kivy
+    aiofiles
+    pyserial
+
+    xclip
+  ];
+}


### PR DESCRIPTION
this makes it a lot easier to set up an environment that has the dependencies
(with [`Nix`](https://nixos.org/download.html) installed, one only has to invoke `nix-shell` and you can run `python3 main.py`)

i had a bunch more dependencies in this, but removing them seems to make no difference to the startup info
i assume the kivy package supplies most of the ones that are actually needed at runtime
```
setuptools
gst-python
pillow
SDL2
pkg-config
libGL
gst_all_1.gstreamer
git
mtdev
xsel
```

i don't have a smoothieboard at hand yet to confirm any functionality beyond starting smoopi though