### PR TITLE
When usb read times out, data is an empty array

### DIFF
--- a/modules/whb04b.py
+++ b/modules/whb04b.py
@@ -386,7 +386,7 @@ class WHB04B():
                     while not self.quit:
                         data = self.hid.recv(timeout=1000)
 
-                        if data is None:
+                        if not data:
                             continue
 
                         size = len(data)


### PR DESCRIPTION
This change avoids a message appearing every second about "Incorrect packet size" when the pendant
is idle.