### PR TITLE
WHB04B fix: Deduplicate enumerated devices by device path

### DIFF
--- a/modules/whb04b.py
+++ b/modules/whb04b.py
@@ -63,6 +63,10 @@ class WHB04BHID:
             Logger.debug("WHB04BHID: No matching device found")
             return None
 
+        # HIDAPI bug: same device is listed multiple times
+        seen = set()
+        devices = [obj for obj in devices if obj.path not in seen and not seen.add(obj.path)]
+
         if len(devices) > 1:
             Logger.debug(f"WHB04BHID: more than one device found: {devices}")
             return None


### PR DESCRIPTION
On Debian Bullseye that ships hidapi 0.10.1,  the same device shows multiple times, which causes the WHB04B module to fail initialization.

This hidapi issue mentions that the same device may appear multiple times in the device enumeration:
https://github.com/libusb/hidapi/issues/298

Here's another project's workaround for this issue: https://github.com/mixxxdj/mixxx/pull/4054/commits/5c582575a06f28e9c42b1261f5b475024c0f186b